### PR TITLE
Fix MediaType Typo in MediaCard.vue

### DIFF
--- a/src/components/media/MediaCard.vue
+++ b/src/components/media/MediaCard.vue
@@ -102,7 +102,7 @@ const hasNewEpisodes = computed(() => {
                     {{
                         props.media.title }}</h3>
                 <div class="flex justify-between items-center mt-1 text-xs text-gray-400">
-                    <span class="capitalize">{{ mediaType }}</span>
+                    <span>{{ mediaType === 'tv' ? 'TV' : 'Movie' }}</span>
                     <span>{{ year }}</span>
                 </div>
             </CardContent>


### PR DESCRIPTION
Closes #1. Fixed the display of MediaType to show "TV" instead of "Tv".