### PR TITLE
feat: Implement Design System with Shadcn Tokens

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://shadcn-vue.com/schema.json",
+  "style": "default",
+  "typescript": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/styles/global.css",
+    "baseColor": "zinc",
+    "cssVariables": true
+  },
+  "framework": "astro",
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils"
+  }
+}


### PR DESCRIPTION
Closes #2

## Summary
Completes the shadcn-vue design system setup by adding the missing `components.json` configuration file.

## Changes
- **components.json**: shadcn-vue CLI configuration for Astro + Vue + Tailwind v4
  - Uses Zinc dark theme with CSS variables
  - Points to existing `src/styles/global.css` and `@/lib/utils`

## Already in place (no changes needed)
- ✅ `src/styles/global.css` - Tailwind v4 `@theme` tokens + Zinc Dark CSS variables  
- ✅ `src/lib/utils.ts` - `cn()` utility with clsx + tailwind-merge
- ✅ Dependencies: radix-vue, class-variance-authority, clsx, tailwind-merge

## Testing
- `pnpm run build` passes ✅