### PR TITLE
feat: Trakt.tv OAuth Connection Flow

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://shadcn-vue.com/schema.json",
+  "style": "default",
+  "typescript": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/styles/global.css",
+    "baseColor": "zinc",
+    "cssVariables": true
+  },
+  "framework": "astro",
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils"
+  }
+}

--- a/drizzle/migrations/0010_smooth_the_executioner.sql
+++ b/drizzle/migrations/0010_smooth_the_executioner.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "account_connections" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"provider" text NOT NULL,
+	"access_token" text NOT NULL,
+	"refresh_token" text,
+	"expires_at" timestamp,
+	"provider_user_id" text,
+	"provider_username" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "account_connections" ADD CONSTRAINT "account_connections_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "account_connections_user_provider_unique" ON "account_connections" USING btree ("user_id","provider");

--- a/drizzle/migrations/meta/0010_snapshot.json
+++ b/drizzle/migrations/meta/0010_snapshot.json
@@ -1,0 +1,1506 @@
+{
+  "id": "831ce68e-5edf-40c2-ab44-b913ccf5e678",
+  "prevId": "c36cf6d4-3b1b-452a-b1c2-4c5224459976",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_connections": {
+      "name": "account_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_username": {
+          "name": "provider_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_connections_user_provider_unique": {
+          "name": "account_connections_user_provider_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_connections_user_id_users_id_fk": {
+          "name": "account_connections_user_id_users_id_fk",
+          "tableFrom": "account_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authors": {
+          "name": "authors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_date": {
+          "name": "published_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "average_rating": {
+          "name": "average_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ratings_count": {
+          "name": "ratings_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ebook": {
+          "name": "is_ebook",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "books_google_id_unique": {
+          "name": "books_google_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.episodes": {
+      "name": "episodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_number": {
+          "name": "episode_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "still_path": {
+          "name": "still_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote_average": {
+          "name": "vote_average",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "episodes_tmdb_id_unique": {
+          "name": "episodes_tmdb_id_unique",
+          "columns": [
+            {
+              "expression": "tmdb_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "episodes_season_id_seasons_id_fk": {
+          "name": "episodes_season_id_seasons_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friendships": {
+      "name": "friendships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "friendships_user_friend_unique": {
+          "name": "friendships_user_friend_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friendships_user_id_users_id_fk": {
+          "name": "friendships_user_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "friendships_friend_id_users_id_fk": {
+          "name": "friendships_friend_id_users_id_fk",
+          "tableFrom": "friendships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_items": {
+      "name": "media_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_title": {
+          "name": "original_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_air_date": {
+          "name": "last_air_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote_average": {
+          "name": "vote_average",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_items_tmdb_id_type_unique": {
+          "name": "media_items_tmdb_id_type_unique",
+          "columns": [
+            {
+              "expression": "tmdb_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.podcasts": {
+      "name": "podcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "listen_notes_id": {
+          "name": "listen_notes_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itunes_id": {
+          "name": "itunes_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_name": {
+          "name": "collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_episodes": {
+          "name": "total_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listen_score": {
+          "name": "listen_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "podcasts_listen_notes_id_unique": {
+          "name": "podcasts_listen_notes_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "listen_notes_id"
+          ]
+        },
+        "podcasts_itunes_id_unique": {
+          "name": "podcasts_itunes_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "itunes_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ratings": {
+      "name": "ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ratings_user_id_users_id_fk": {
+          "name": "ratings_user_id_users_id_fk",
+          "tableFrom": "ratings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ratings_media_item_id_media_items_id_fk": {
+          "name": "ratings_media_item_id_media_items_id_fk",
+          "tableFrom": "ratings",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "episode_count": {
+          "name": "episode_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote_average": {
+          "name": "vote_average",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "seasons_tmdb_id_unique": {
+          "name": "seasons_tmdb_id_unique",
+          "columns": [
+            {
+              "expression": "tmdb_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "seasons_media_item_id_media_items_id_fk": {
+          "name": "seasons_media_item_id_media_items_id_fk",
+          "tableFrom": "seasons",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_book_progress": {
+      "name": "user_book_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_book_progress_user_book_unique": {
+          "name": "user_book_progress_user_book_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_book_progress_user_id_users_id_fk": {
+          "name": "user_book_progress_user_id_users_id_fk",
+          "tableFrom": "user_book_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_book_progress_book_id_books_id_fk": {
+          "name": "user_book_progress_book_id_books_id_fk",
+          "tableFrom": "user_book_progress",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_podcast_progress": {
+      "name": "user_podcast_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "podcast_id": {
+          "name": "podcast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_podcast_progress_user_podcast_unique": {
+          "name": "user_podcast_progress_user_podcast_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "podcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_podcast_progress_user_id_users_id_fk": {
+          "name": "user_podcast_progress_user_id_users_id_fk",
+          "tableFrom": "user_podcast_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_podcast_progress_podcast_id_podcasts_id_fk": {
+          "name": "user_podcast_progress_podcast_id_podcasts_id_fk",
+          "tableFrom": "user_podcast_progress",
+          "tableTo": "podcasts",
+          "columnsFrom": [
+            "podcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_progress": {
+      "name": "user_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_progress_user_media_unique": {
+          "name": "user_progress_user_media_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_progress_user_id_users_id_fk": {
+          "name": "user_progress_user_id_users_id_fk",
+          "tableFrom": "user_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_progress_media_item_id_media_items_id_fk": {
+          "name": "user_progress_media_item_id_media_items_id_fk",
+          "tableFrom": "user_progress",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1768959894140,
       "tag": "0009_nosy_emma_frost",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1770245500133,
+      "tag": "0010_smooth_the_executioner",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -188,3 +188,18 @@ export const friendships = pgTable('friendships', {
 }, (t) => ({
     unq: uniqueIndex('friendships_user_friend_unique').on(t.userId, t.friendId),
 }));
+
+export const accountConnections = pgTable('account_connections', {
+    id: serial('id').primaryKey(),
+    userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    provider: text('provider').notNull(), // 'trakt'
+    accessToken: text('access_token').notNull(),
+    refreshToken: text('refresh_token'),
+    expiresAt: timestamp('expires_at'),
+    providerUserId: text('provider_user_id'), // trakt user id
+    providerUsername: text('provider_username'), // trakt username
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+    unq: uniqueIndex('account_connections_user_provider_unique').on(t.userId, t.provider),
+}));

--- a/src/components/settings/TraktConnection.vue
+++ b/src/components/settings/TraktConnection.vue
@@ -1,0 +1,168 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { Loader2, Link2, Unlink, ExternalLink, CheckCircle2, AlertCircle } from 'lucide-vue-next';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface TraktStatus {
+    connected: boolean;
+    username?: string;
+    userId?: string;
+    connectedAt?: string;
+    expired?: boolean;
+}
+
+const loading = ref(true);
+const disconnecting = ref(false);
+const status = ref<TraktStatus | null>(null);
+const error = ref<string | null>(null);
+
+const fetchStatus = async () => {
+    loading.value = true;
+    error.value = null;
+    try {
+        const response = await fetch('/api/auth/trakt/status');
+        if (!response.ok) {
+            throw new Error('Failed to fetch Trakt status');
+        }
+        status.value = await response.json();
+    } catch (e) {
+        console.error('Error fetching Trakt status:', e);
+        error.value = 'Failed to load connection status';
+    } finally {
+        loading.value = false;
+    }
+};
+
+const connectTrakt = () => {
+    // Redirect to the OAuth flow
+    window.location.href = '/api/auth/trakt/connect';
+};
+
+const disconnectTrakt = async () => {
+    if (!confirm('Are you sure you want to disconnect your Trakt account?')) {
+        return;
+    }
+
+    disconnecting.value = true;
+    error.value = null;
+    try {
+        const response = await fetch('/api/auth/trakt/disconnect', {
+            method: 'POST',
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest',
+            },
+        });
+        if (!response.ok) {
+            throw new Error('Failed to disconnect Trakt');
+        }
+        status.value = { connected: false };
+    } catch (e) {
+        console.error('Error disconnecting Trakt:', e);
+        error.value = 'Failed to disconnect Trakt account';
+    } finally {
+        disconnecting.value = false;
+    }
+};
+
+onMounted(() => {
+    fetchStatus();
+    
+    // Check URL for callback messages
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('trakt') === 'connected') {
+        // Clean URL without reload
+        window.history.replaceState({}, '', window.location.pathname);
+    }
+    if (urlParams.get('error')?.startsWith('trakt')) {
+        error.value = 'Failed to connect Trakt account. Please try again.';
+        window.history.replaceState({}, '', window.location.pathname);
+    }
+});
+</script>
+
+<template>
+    <Card>
+        <CardHeader>
+            <CardTitle class="flex items-center gap-2">
+                <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-2-5.17l-2.59-2.59L6 13.66l4 4 8-8-1.41-1.42z"/>
+                </svg>
+                Trakt.tv
+            </CardTitle>
+            <CardDescription>
+                Connect your Trakt.tv account to sync your watch history and ratings.
+            </CardDescription>
+        </CardHeader>
+        <CardContent>
+            <div v-if="loading" class="flex items-center justify-center py-4">
+                <Loader2 class="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+
+            <div v-else-if="error" class="p-3 bg-destructive/10 border border-destructive/20 rounded-lg mb-4">
+                <p class="text-sm text-destructive flex items-center gap-2">
+                    <AlertCircle class="h-4 w-4" />
+                    {{ error }}
+                </p>
+            </div>
+
+            <div v-else-if="status?.connected" class="space-y-4">
+                <div class="flex items-center gap-3 p-3 bg-green-500/10 border border-green-500/20 rounded-lg">
+                    <CheckCircle2 class="h-5 w-5 text-green-500 flex-shrink-0" />
+                    <div class="flex-1 min-w-0">
+                        <p class="text-sm font-medium text-green-600 dark:text-green-400">Connected</p>
+                        <p class="text-sm text-muted-foreground truncate">
+                            Signed in as <a 
+                                :href="`https://trakt.tv/users/${status.username}`"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="font-medium text-foreground hover:underline inline-flex items-center gap-1"
+                            >
+                                @{{ status.username }}
+                                <ExternalLink class="h-3 w-3" />
+                            </a>
+                        </p>
+                    </div>
+                </div>
+
+                <div v-if="status.expired" class="p-3 bg-yellow-500/10 border border-yellow-500/20 rounded-lg">
+                    <p class="text-sm text-yellow-600 dark:text-yellow-400 flex items-center gap-2">
+                        <AlertCircle class="h-4 w-4" />
+                        Your connection has expired. Please reconnect to continue syncing.
+                    </p>
+                </div>
+
+                <div class="flex gap-2">
+                    <Button 
+                        v-if="status.expired"
+                        @click="connectTrakt" 
+                        class="flex-1"
+                    >
+                        <Link2 class="mr-2 h-4 w-4" />
+                        Reconnect
+                    </Button>
+                    <Button 
+                        variant="outline" 
+                        @click="disconnectTrakt"
+                        :disabled="disconnecting"
+                        :class="status.expired ? '' : 'w-full'"
+                    >
+                        <Loader2 v-if="disconnecting" class="mr-2 h-4 w-4 animate-spin" />
+                        <Unlink v-else class="mr-2 h-4 w-4" />
+                        Disconnect
+                    </Button>
+                </div>
+            </div>
+
+            <div v-else class="space-y-4">
+                <p class="text-sm text-muted-foreground">
+                    Link your Trakt.tv account to automatically track the movies and shows you watch.
+                </p>
+                <Button @click="connectTrakt" class="w-full">
+                    <Link2 class="mr-2 h-4 w-4" />
+                    Connect Trakt Account
+                </Button>
+            </div>
+        </CardContent>
+    </Card>
+</template>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -61,6 +61,7 @@ export const createAuth = (env: any, dbInstance?: Db) => {
     };
 
     return betterAuth({
+        trustedOrigins: ["https://traktdb.niteshrijal.com"],
         secret: env.AUTH_SECRET || import.meta.env.AUTH_SECRET,
         database: adapter,
         socialProviders: {

--- a/src/pages/api/auth/trakt/callback.ts
+++ b/src/pages/api/auth/trakt/callback.ts
@@ -1,0 +1,112 @@
+import type { APIRoute } from 'astro';
+import { createAuth } from '@/lib/auth';
+import { createDb } from '@/lib/db';
+import { accountConnections } from 'drizzle/schema';
+import { and, eq } from 'drizzle-orm';
+
+export const GET: APIRoute = async ({ request, locals, redirect }) => {
+    const env = locals.runtime?.env || import.meta.env;
+    const auth = createAuth(env);
+    const db = createDb(env);
+
+    const session = await auth.api.getSession({ headers: request.headers });
+    if (!session) {
+        return redirect('/login?error=unauthorized');
+    }
+
+    const url = new URL(request.url);
+    const code = url.searchParams.get('code');
+    const state = url.searchParams.get('state');
+
+    if (!code) {
+        return redirect('/profile?error=trakt_auth_failed');
+    }
+
+    // Verify state matches the user
+    if (state !== session.user.id) {
+        return redirect('/profile?error=trakt_state_mismatch');
+    }
+
+    const clientId = env.TRAKT_CLIENT_ID || import.meta.env.TRAKT_CLIENT_ID;
+    const clientSecret = env.TRAKT_CLIENT_SECRET || import.meta.env.TRAKT_CLIENT_SECRET;
+    const redirectUri = env.TRAKT_REDIRECT_URI || import.meta.env.TRAKT_REDIRECT_URI;
+
+    if (!clientId || !clientSecret || !redirectUri) {
+        return redirect('/profile?error=trakt_not_configured');
+    }
+
+    try {
+        // Exchange code for tokens
+        const tokenResponse = await fetch('https://api.trakt.tv/oauth/token', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                code,
+                client_id: clientId,
+                client_secret: clientSecret,
+                redirect_uri: redirectUri,
+                grant_type: 'authorization_code',
+            }),
+        });
+
+        if (!tokenResponse.ok) {
+            console.error('Trakt token exchange failed:', await tokenResponse.text());
+            return redirect('/profile?error=trakt_token_failed');
+        }
+
+        const tokens = await tokenResponse.json();
+
+        // Get user info from Trakt
+        const userResponse = await fetch('https://api.trakt.tv/users/me', {
+            headers: {
+                'Content-Type': 'application/json',
+                'trakt-api-version': '2',
+                'trakt-api-key': clientId,
+                'Authorization': `Bearer ${tokens.access_token}`,
+            },
+        });
+
+        if (!userResponse.ok) {
+            console.error('Trakt user fetch failed:', await userResponse.text());
+            return redirect('/profile?error=trakt_user_failed');
+        }
+
+        const traktUser = await userResponse.json();
+
+        // Calculate token expiration
+        const expiresAt = tokens.expires_in 
+            ? new Date(Date.now() + tokens.expires_in * 1000)
+            : null;
+
+        // Upsert the connection
+        await db.insert(accountConnections)
+            .values({
+                userId: session.user.id,
+                provider: 'trakt',
+                accessToken: tokens.access_token,
+                refreshToken: tokens.refresh_token || null,
+                expiresAt,
+                providerUserId: traktUser.ids?.slug || traktUser.username,
+                providerUsername: traktUser.username,
+                updatedAt: new Date(),
+            })
+            .onConflictDoUpdate({
+                target: [accountConnections.userId, accountConnections.provider],
+                set: {
+                    accessToken: tokens.access_token,
+                    refreshToken: tokens.refresh_token || null,
+                    expiresAt,
+                    providerUserId: traktUser.ids?.slug || traktUser.username,
+                    providerUsername: traktUser.username,
+                    updatedAt: new Date(),
+                },
+            });
+
+        return redirect('/profile?trakt=connected');
+    } catch (error) {
+        console.error('Trakt callback error:', error);
+        return redirect('/profile?error=trakt_error');
+    }
+};

--- a/src/pages/api/auth/trakt/connect.ts
+++ b/src/pages/api/auth/trakt/connect.ts
@@ -1,0 +1,29 @@
+import type { APIRoute } from 'astro';
+import { createAuth } from '@/lib/auth';
+
+export const GET: APIRoute = async ({ request, locals, redirect }) => {
+    const env = locals.runtime?.env || import.meta.env;
+    const auth = createAuth(env);
+
+    const session = await auth.api.getSession({ headers: request.headers });
+    if (!session) {
+        return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+    }
+
+    const clientId = env.TRAKT_CLIENT_ID || import.meta.env.TRAKT_CLIENT_ID;
+    const redirectUri = env.TRAKT_REDIRECT_URI || import.meta.env.TRAKT_REDIRECT_URI;
+
+    if (!clientId || !redirectUri) {
+        return new Response(JSON.stringify({ error: 'Trakt OAuth not configured' }), { status: 500 });
+    }
+
+    const authUrl = new URL('https://trakt.tv/oauth/authorize');
+    authUrl.searchParams.set('response_type', 'code');
+    authUrl.searchParams.set('client_id', clientId);
+    authUrl.searchParams.set('redirect_uri', redirectUri);
+    
+    // Store user ID in state to verify on callback
+    authUrl.searchParams.set('state', session.user.id);
+
+    return redirect(authUrl.toString());
+};

--- a/src/pages/api/auth/trakt/disconnect.ts
+++ b/src/pages/api/auth/trakt/disconnect.ts
@@ -1,0 +1,65 @@
+import type { APIRoute } from 'astro';
+import { createAuth } from '@/lib/auth';
+import { createDb } from '@/lib/db';
+import { accountConnections } from 'drizzle/schema';
+import { and, eq } from 'drizzle-orm';
+
+export const POST: APIRoute = async ({ request, locals }) => {
+    const env = locals.runtime?.env || import.meta.env;
+    const auth = createAuth(env);
+    const db = createDb(env);
+
+    const session = await auth.api.getSession({ headers: request.headers });
+    if (!session) {
+        return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+    }
+
+    // CSRF Protection
+    const requestedWith = request.headers.get('x-requested-with');
+    if (requestedWith !== 'XMLHttpRequest') {
+        return new Response(JSON.stringify({ error: 'Missing Anti-CSRF Header' }), { status: 403 });
+    }
+
+    try {
+        // Optionally revoke the token at Trakt (best practice)
+        const connection = await db.select()
+            .from(accountConnections)
+            .where(and(
+                eq(accountConnections.userId, session.user.id),
+                eq(accountConnections.provider, 'trakt')
+            ))
+            .limit(1);
+
+        if (connection.length > 0) {
+            const clientId = env.TRAKT_CLIENT_ID || import.meta.env.TRAKT_CLIENT_ID;
+            const clientSecret = env.TRAKT_CLIENT_SECRET || import.meta.env.TRAKT_CLIENT_SECRET;
+
+            // Attempt to revoke token at Trakt (non-blocking)
+            if (clientId && clientSecret) {
+                fetch('https://api.trakt.tv/oauth/revoke', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        token: connection[0].accessToken,
+                        client_id: clientId,
+                        client_secret: clientSecret,
+                    }),
+                }).catch(err => console.error('Failed to revoke Trakt token:', err));
+            }
+        }
+
+        // Delete the connection from our database
+        await db.delete(accountConnections)
+            .where(and(
+                eq(accountConnections.userId, session.user.id),
+                eq(accountConnections.provider, 'trakt')
+            ));
+
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+    } catch (error) {
+        console.error('Trakt disconnect error:', error);
+        return new Response(JSON.stringify({ error: 'Internal Server Error' }), { status: 500 });
+    }
+};

--- a/src/pages/api/auth/trakt/status.ts
+++ b/src/pages/api/auth/trakt/status.ts
@@ -1,0 +1,51 @@
+import type { APIRoute } from 'astro';
+import { createAuth } from '@/lib/auth';
+import { createDb } from '@/lib/db';
+import { accountConnections } from 'drizzle/schema';
+import { and, eq } from 'drizzle-orm';
+
+export const GET: APIRoute = async ({ request, locals }) => {
+    const env = locals.runtime?.env || import.meta.env;
+    const auth = createAuth(env);
+    const db = createDb(env);
+
+    const session = await auth.api.getSession({ headers: request.headers });
+    if (!session) {
+        return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+    }
+
+    try {
+        const connection = await db.select({
+            providerUsername: accountConnections.providerUsername,
+            providerUserId: accountConnections.providerUserId,
+            expiresAt: accountConnections.expiresAt,
+            createdAt: accountConnections.createdAt,
+        })
+            .from(accountConnections)
+            .where(and(
+                eq(accountConnections.userId, session.user.id),
+                eq(accountConnections.provider, 'trakt')
+            ))
+            .limit(1);
+
+        if (connection.length === 0) {
+            return new Response(JSON.stringify({ 
+                connected: false 
+            }), { status: 200 });
+        }
+
+        const conn = connection[0];
+        const isExpired = conn.expiresAt && new Date(conn.expiresAt) < new Date();
+
+        return new Response(JSON.stringify({
+            connected: true,
+            username: conn.providerUsername,
+            userId: conn.providerUserId,
+            connectedAt: conn.createdAt,
+            expired: isExpired,
+        }), { status: 200 });
+    } catch (error) {
+        console.error('Trakt status error:', error);
+        return new Response(JSON.stringify({ error: 'Internal Server Error' }), { status: 500 });
+    }
+};

--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -1,6 +1,7 @@
 ---
 import AppLayout from "@/layouts/AppLayout.astro";
 import ProfileForm from "@/components/profile/ProfileForm.vue";
+import TraktConnection from "@/components/settings/TraktConnection.vue";
 
 const { user } = Astro.locals;
 
@@ -20,6 +21,16 @@ if (!user) {
             </div>
             <div class="h-px bg-border"></div>
             <ProfileForm client:load />
+            
+            <div class="h-px bg-border"></div>
+            
+            <div>
+                <h3 class="text-lg font-medium">Connected Accounts</h3>
+                <p class="text-sm text-muted-foreground">
+                    Link external services to enhance your experience.
+                </p>
+            </div>
+            <TraktConnection client:load />
         </div>
     </div>
 </AppLayout>


### PR DESCRIPTION
Implements Trakt.tv OAuth connection flow allowing users to link their Trakt accounts.

## Changes
- **Schema**: Added `account_connections` table to store provider connections (Trakt initially)
- **API Endpoints**:
  - `GET /api/auth/trakt/connect` - Initiates OAuth redirect to Trakt
  - `GET /api/auth/trakt/callback` - Handles OAuth callback, exchanges code for tokens, stores connection
  - `POST /api/auth/trakt/disconnect` - Removes connection and revokes token at Trakt
  - `GET /api/auth/trakt/status` - Returns current Trakt connection status
- **UI**: Added TraktConnection.vue component showing connect/disconnect UI
- **Profile Page**: Added "Connected Accounts" section with Trakt integration

## Environment Variables Required
The following env vars need to be set before using:
- `TRAKT_CLIENT_ID` - Trakt API Client ID
- `TRAKT_CLIENT_SECRET` - Trakt API Client Secret  
- `TRAKT_REDIRECT_URI` - Callback URL (e.g., https://traktdb.niteshrijal.com/api/auth/trakt/callback)

## Migration
Run `pnpm run db:push` or apply migration `0010_smooth_the_executioner.sql` to create the `account_connections` table.

Closes #19