### PR TITLE
[search] Fix omni search pagination and image handling

### DIFF
--- a/src/components/media/MediaHeader.vue
+++ b/src/components/media/MediaHeader.vue
@@ -3,7 +3,8 @@ import { computed } from 'vue';
 import { Star, Calendar, Info } from 'lucide-vue-next';
 import WatchStatusButton from './WatchStatusButton.vue';
 
-import { TMDB_IMAGE_BASE_URL, MediaType } from '@/lib/constants';
+import { MediaType, PLACEHOLDER_IMAGE_URL } from '@/lib/constants';
+import { getTmdbImageUrl } from '@/lib/images';
 
 const props = defineProps<{
     media: {
@@ -22,15 +23,11 @@ const props = defineProps<{
 }>();
 
 const backdropUrl = computed(() =>
-    props.media.backdrop_path
-        ? `https://image.tmdb.org/t/p/w1920_and_h800_multi_faces${props.media.backdrop_path}`
-        : null
+    getTmdbImageUrl(props.media.backdrop_path, 'backdrop')
 );
 
 const posterUrl = computed(() =>
-    props.media.poster_path
-        ? `https://image.tmdb.org/t/p/w500${props.media.poster_path}`
-        : 'https://placehold.co/500x750?text=No+Image'
+    getTmdbImageUrl(props.media.poster_path) || PLACEHOLDER_IMAGE_URL
 );
 
 const year = computed(() => {

--- a/src/components/podcasts/PodcastHeader.vue
+++ b/src/components/podcasts/PodcastHeader.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 import { Headphones, Podcast, ExternalLink, ArrowLeft } from 'lucide-vue-next';
 import ListenStatusButton from './ListenStatusButton.vue';
+import { getPodcastArtwork } from '@/lib/images';
 
 const props = defineProps<{
     podcast: {
@@ -22,7 +23,10 @@ const props = defineProps<{
 }>();
 
 const imageUrl = computed(() =>
-    props.podcast.image || props.podcast.thumbnail || null
+    getPodcastArtwork({
+        artworkUrl600: props.podcast.image || undefined,
+        artworkUrl100: props.podcast.thumbnail || undefined,
+    })
 );
 
 const podcastExternalId = computed(() =>

--- a/src/components/search/OmniSearchPage.test.ts
+++ b/src/components/search/OmniSearchPage.test.ts
@@ -114,9 +114,14 @@ describe('OmniSearchPage', () => {
             writable: true,
         });
 
-        vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+        vi.spyOn(global, 'fetch')
+            .mockResolvedValueOnce({
             ok: true,
             json: () => Promise.resolve(mockOmniResponse),
+        } as Response)
+            .mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ results: [] }),
         } as Response);
 
         const wrapper = mount(OmniSearchPage);
@@ -126,6 +131,9 @@ describe('OmniSearchPage', () => {
 
         expect(global.fetch).toHaveBeenCalledWith(
             expect.stringContaining('/api/search/omni?q=batman'),
+        );
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining('/api/search/multi?q=batman&page=1'),
         );
     });
 });

--- a/src/pages/api/search/omni.ts
+++ b/src/pages/api/search/omni.ts
@@ -4,7 +4,7 @@ import { createGoogleBooks } from '@/lib/google-books';
 import { createListenNotes } from '@/lib/listennotes';
 import { createITunes } from '@/lib/itunes';
 import { MediaType } from '@/lib/constants';
-import { getTmdbImageUrl, getBookThumbnail, getPodcastArtwork, ensureHttps } from '@/lib/images';
+import { getTmdbImageUrl, getBookThumbnail, getPodcastArtwork } from '@/lib/images';
 
 interface OmniResult {
     id: string | number;


### PR DESCRIPTION
## Summary
- use shared image helpers and local placeholder for media/podcast headers
- fetch per-category search data for books/podcasts and support load-more on all tabs
- clean up unused import

## Testing
- not run (local)

## Issues
Closes #146
Closes #147
Closes #148
Closes #149
Closes #150
Closes #151
Closes #152
